### PR TITLE
Adiciona link para formatação do log do GIT

### DIFF
--- a/git.md
+++ b/git.md
@@ -1,4 +1,12 @@
 # Git
 
 - [Baixar arquivos via `git bash`](https://stackoverflow.com/questions/47838054/download-file-to-my-computer-using-git-bash).
+- [Git log format string cheatsheet](https://devhints.io/git-log-format)
 
+## Comandos legais
+
+Exige o log do git filtrando por autor, no formato para relatórios de trabalho
+
+~~~git
+git log --author='Jefferson Neves' --no-merges --abbrev-commit --date=short --pretty=format:'%Cred%h%Creset %C(bold blue)<%an>%Creset %Cgreen(%ci)%Creset %s'
+~~~


### PR DESCRIPTION
No link é possivel ver a os códigos para formatação do log do GIT.
De quebra tem um comando de exemplo que formata a data, remove os merges e filtra por autor (ideal para ajudar em relatórios de trabalho)